### PR TITLE
Correctly handle recurrence exceptions

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -42,7 +42,7 @@ async function main() {
         const it = event.recurrenceIterator;
         let nextOccurrence: any;
         while ((nextOccurrence = it.next())) {
-          const nextOccurrenceStartDate = nextOccurrence.toJSDate();
+          const nextOccurrenceStartDate = nextOccurrence.startDate.toJSDate();
 
           // Ignoring occurrences which are before the range and
           // stopping the loop once the end of the range has been reached
@@ -51,10 +51,7 @@ async function main() {
 
           const eventDuration =
             event.endDate.getTime() - event.startDate.getTime();
-          const nextOccurrenceEndDate = new Date();
-          nextOccurrenceEndDate.setTime(
-            nextOccurrenceStartDate.getTime() + eventDuration
-          );
+          const nextOccurrenceEndDate = nextOccurrence.endDate.toJSDate();
           const nextOccurrenceEvent: CalDAVEvent = {
             ...event,
             uid: `${event.uid}-${nextOccurrenceStartDate.getTime()}`,

--- a/src/caldav/caldav.service.ts
+++ b/src/caldav/caldav.service.ts
@@ -297,7 +297,7 @@ export class CalDAVService {
             attendees,
             isRecurring: event.isRecurring(),
             recurrenceId: event.recurrenceId,
-            recurrenceIterator: event.iterator(),
+            recurrenceIterator: new RecurrenceIterator(event),
             allDayEvent: this.isAllDayEvent(duration),
             tzid,
             iCalendarData: iCalData
@@ -308,5 +308,23 @@ export class CalDAVService {
 
     private isAllDayEvent(duration: CalendarEventDuration) {
         return duration.days === 1 && duration.hours === 0 && duration.minutes === 0 && duration.seconds === 0 && duration.weeks === 0;
+    }
+}
+
+
+class RecurrenceIterator{
+    /**
+     * An iterator of recurrent events. It uses getOccurrenceDetails to correctly handle exceptions.
+     */
+    _event = null;
+    _iter = null;
+
+    public constructor(event: ICAL.event) {
+      this._event = event;
+      this._iter = event.iterator();
+    }
+
+    public next() {
+      return this._event.getOccurrenceDetails(this._iter.next());
     }
 }


### PR DESCRIPTION
A recurrent event can have exceptions, where one occurrence of it may have a different startdate/enddate from the original event.  This is handled by the `getOccurenceDetails` function at https://github.com/kewisch/ical.js/blob/35533497954b2c6e20a902789fe11e95740c3cf6/lib/ical/event.js#L192-L202

This PR lets the recurrence iterator calls `getOccurrenceDetails` for each occurrence, so it can get correct startDate/endDate.

https://github.com/kewisch/ical.js/blob/35533497954b2c6e20a902789fe11e95740c3cf6/lib/ical/recur_expansion.js#L17-L18 also indicates that the iterator alone does not handle exceptions, and should be used together with the event to handle exceptions.